### PR TITLE
feat: Add reset functionality to various cubits and improve state management in AddVehicleScreen

### DIFF
--- a/lib/core/widgets/full_screen_photo_view.dart
+++ b/lib/core/widgets/full_screen_photo_view.dart
@@ -1,19 +1,25 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:photo_view/photo_view.dart';
+import 'package:uuid/uuid.dart';
 
 class FullScreenPhotoView extends StatelessWidget {
   final File image;
   final VoidCallback? onRemove;
+  final String? heroTag;
 
   const FullScreenPhotoView({
     super.key,
     required this.image,
     this.onRemove,
+    this.heroTag,
   });
 
   @override
   Widget build(BuildContext context) {
+    final String uniqueHeroTag =
+        heroTag ?? '${image.path}_${const Uuid().v4()}';
+
     return Scaffold(
       backgroundColor: Colors.black,
       appBar: AppBar(
@@ -31,7 +37,7 @@ class FullScreenPhotoView extends StatelessWidget {
         imageProvider: FileImage(image),
         minScale: PhotoViewComputedScale.contained,
         maxScale: PhotoViewComputedScale.covered * 2,
-        heroAttributes: PhotoViewHeroAttributes(tag: image.path),
+        heroAttributes: PhotoViewHeroAttributes(tag: uniqueHeroTag),
         backgroundDecoration: const BoxDecoration(
           color: Colors.black,
         ),

--- a/lib/features/main_screen/renter/presentation/views/renter_bottom_navigation_bar_view.dart
+++ b/lib/features/main_screen/renter/presentation/views/renter_bottom_navigation_bar_view.dart
@@ -5,6 +5,11 @@ import 'package:aggar/core/widgets/custom_bottom_navigation_bar.dart';
 import 'package:aggar/features/authorization/presentation/views/sign_in_view.dart';
 import 'package:aggar/features/main_screen/renter/presentation/views/main_screen.dart';
 import 'package:aggar/features/messages/views/messages_status/presentation/views/messages_view.dart';
+import 'package:aggar/features/new_vehicle/data/cubits/add_vehicle_cubit/add_vehicle_cubit.dart';
+import 'package:aggar/features/new_vehicle/data/cubits/additinal_images_cubit/additinal_images_cubit.dart';
+import 'package:aggar/features/new_vehicle/data/cubits/main_image_cubit/main_image_cubit.dart';
+import 'package:aggar/features/new_vehicle/data/cubits/map_location/map_location_cubit.dart';
+import 'package:aggar/features/new_vehicle/presentation/views/add_vehicle_screen.dart';
 import 'package:aggar/features/settings/presentation/views/settings_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -59,13 +64,20 @@ class _RenterBottomNavigationBarViewState
     });
   }
 
+  void _resetVehicleForm() {
+    context.read<AddVehicleCubit>().reset();
+    context.read<MainImageCubit>().reset();
+    context.read<AdditionalImageCubit>().reset();
+    context.read<MapLocationCubit>().reset();
+  }
+
   @override
   Widget build(BuildContext context) {
     List<Widget> screens = [
       const MainScreen(),
       const MessagesView(),
       const SettingsScreen(),
-      const MainScreen(), // You might want to replace this with a different screen
+      const MainScreen(),
     ];
 
     return BlocListener<TokenRefreshCubit, TokenRefreshState>(
@@ -82,6 +94,27 @@ class _RenterBottomNavigationBarViewState
         }
       },
       child: Scaffold(
+        floatingActionButton: FloatingActionButton(
+          heroTag: "Dddd",
+          onPressed: () {
+            _resetVehicleForm();
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => const AddVehicleScreen(),
+              ),
+            );
+          },
+          backgroundColor: context.theme.blue100_1,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(50),
+          ),
+          child: Icon(
+            Icons.add,
+            color: context.theme.white100_1,
+            size: 30,
+          ),
+        ),
         backgroundColor: context.theme.white100_1,
         body: AnimatedSwitcher(
           duration: const Duration(milliseconds: 300),

--- a/lib/features/new_vehicle/data/cubits/add_vehicle_cubit/add_vehicle_cubit.dart
+++ b/lib/features/new_vehicle/data/cubits/add_vehicle_cubit/add_vehicle_cubit.dart
@@ -27,7 +27,7 @@ class AddVehicleCubit extends Cubit<AddVehicleState> {
       this.additionalImageCubit, this.mapLocationCubit)
       : super(AddVehicleInitial()) {
     selectedTransmissionModeValue = 0; // Default to Automatic
-    emit(TransmissionModeUpdated(selectedTransmissionModeValue));
+    emit(TransmissionModeUpdated(selectedTransmissionModeValue!));
     emit(VehicleStatusUpdated(selectedVehicleStatusValue));
 
     _dio = Dio(BaseOptions(
@@ -58,7 +58,7 @@ class AddVehicleCubit extends Cubit<AddVehicleState> {
 
   void setTransmissionMode(int value) {
     selectedTransmissionModeValue = value;
-    emit(TransmissionModeUpdated(selectedTransmissionModeValue));
+    emit(TransmissionModeUpdated(selectedTransmissionModeValue!));
   }
 
   void setVehicleBrnd(String value, int id) {
@@ -159,7 +159,7 @@ class AddVehicleCubit extends Cubit<AddVehicleState> {
     try {
       emit(AddVehicleLoading());
       if (mainImageFile == null) {
-        emit(AddVehicleFailure('Main image file is required'));
+        emit(const AddVehicleFailure('Main image file is required'));
         return;
       }
 
@@ -295,7 +295,7 @@ class AddVehicleCubit extends Cubit<AddVehicleState> {
       responseData = response.data;
 
       if (response.data == null || response.data['data'] == null) {
-        emit(AddVehicleFailure('No vehicle data found'));
+        emit(const AddVehicleFailure('No vehicle data found'));
         return;
       }
 
@@ -317,9 +317,38 @@ class AddVehicleCubit extends Cubit<AddVehicleState> {
   }
 
   void reset() {
+    // Reset data
     vehicleData = null;
     vehicleId = null;
     responseData = null;
+
+    // Reset form controllers
+    vehicleModelController.clear();
+    vehicleRentalPrice.clear();
+    vehicleYearOfManufactureController.clear();
+    vehicleColorController.clear();
+    vehicleSeatsNoController.clear();
+    vehicleProperitesOverviewController.clear();
+    vehicleBrandController.clear();
+    vehicleTypeController.clear();
+    vehicleStatusController.clear();
+    vehicleAddressController.clear();
+
+    // Reset state values
+    selectedTransmissionModeValue = 0;
+    selectedVehicleBrandValue = null;
+    selectedVehicleTypeValue = null;
+    selectedVehicleStatusValue = null;
+    selectedVehicleBrandId = null;
+    selectedVehicleTypeId = null;
+    selectedVehicleHealthValue = null;
+
+    // Emit initial states
     emit(AddVehicleInitial());
+    emit(TransmissionModeUpdated(selectedTransmissionModeValue ?? 0));
+    emit(VehicleStatusUpdated(selectedVehicleStatusValue));
+    emit(VehicleHealthUpdated(selectedVehicleHealthValue));
+    emit(VehicleBrandUpdated(selectedVehicleBrandValue));
+    emit(VehicleTypeUpdated(selectedVehicleTypeValue));
   }
 }

--- a/lib/features/new_vehicle/data/cubits/add_vehicle_cubit/add_vehicle_state.dart
+++ b/lib/features/new_vehicle/data/cubits/add_vehicle_cubit/add_vehicle_state.dart
@@ -1,9 +1,10 @@
-import 'package:aggar/features/new_vehicle/data/model/vehicle_model.dart';
 import 'package:equatable/equatable.dart';
 
 abstract class AddVehicleState extends Equatable {
+  const AddVehicleState();
+
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 class AddVehicleInitial extends AddVehicleState {}
@@ -11,56 +12,61 @@ class AddVehicleInitial extends AddVehicleState {}
 class AddVehicleLoading extends AddVehicleState {}
 
 class AddVehicleSuccess extends AddVehicleState {
-  final VehicleDataModel vehicleData;
+  final Map<String, dynamic> responseData;
 
-  AddVehicleSuccess(Map<String, dynamic> responseData)
-      : vehicleData = VehicleDataModel.fromJson(responseData);
+  const AddVehicleSuccess(this.responseData);
+
+  @override
+  List<Object?> get props => [responseData];
 }
 
 class VehicleHealthSelected extends AddVehicleState {
   final String? selectedVehicleHealthValue;
 
-  VehicleHealthSelected({this.selectedVehicleHealthValue});
+  const VehicleHealthSelected({this.selectedVehicleHealthValue});
 }
 
 class TransmissionModeUpdated extends AddVehicleState {
-  final int? transmissionMode;
+  final int value;
 
-  TransmissionModeUpdated(this.transmissionMode);
+  const TransmissionModeUpdated(this.value);
 
   @override
-  List<Object> get props => [transmissionMode ?? -1];
+  List<Object?> get props => [value];
 }
 
 class VehicleHealthUpdated extends AddVehicleState {
   final String? selectedVehicleHealthValue;
 
-  VehicleHealthUpdated(this.selectedVehicleHealthValue);
+  const VehicleHealthUpdated(this.selectedVehicleHealthValue);
 }
 
 class VehicleStatusUpdated extends AddVehicleState {
-  final String? selectedVehicleStatusValue;
+  final String? value;
 
-  VehicleStatusUpdated(this.selectedVehicleStatusValue);
+  const VehicleStatusUpdated(this.value);
+
+  @override
+  List<Object?> get props => [value];
 }
 
 class VehicleBrandUpdated extends AddVehicleState {
   final String? selectedVehicleBrandValue;
 
-  VehicleBrandUpdated(this.selectedVehicleBrandValue);
+  const VehicleBrandUpdated(this.selectedVehicleBrandValue);
 }
 
 class VehicleTypeUpdated extends AddVehicleState {
   final String? selectedVehicleTypeValue;
 
-  VehicleTypeUpdated(this.selectedVehicleTypeValue);
+  const VehicleTypeUpdated(this.selectedVehicleTypeValue);
 }
 
 class AddVehicleFailure extends AddVehicleState {
-  final String errorMessage;
+  final String message;
 
-  AddVehicleFailure(this.errorMessage);
+  const AddVehicleFailure(this.message);
 
   @override
-  List<Object> get props => [errorMessage];
+  List<Object?> get props => [message];
 }

--- a/lib/features/new_vehicle/data/cubits/additinal_images_cubit/additinal_images_cubit.dart
+++ b/lib/features/new_vehicle/data/cubits/additinal_images_cubit/additinal_images_cubit.dart
@@ -57,4 +57,9 @@ class AdditionalImageCubit extends Cubit<AdditionalImageState> {
       emit(AdditionalImagesLoaded(images));
     }
   }
+
+  void reset() {
+    images = [];
+    emit(AdditionalImagesInitial());
+  }
 }

--- a/lib/features/new_vehicle/data/cubits/main_image_cubit/main_image_cubit.dart
+++ b/lib/features/new_vehicle/data/cubits/main_image_cubit/main_image_cubit.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-
 import 'package:bloc/bloc.dart';
 import 'package:image_picker/image_picker.dart';
 import 'main_image_state.dart';
@@ -15,6 +14,8 @@ class MainImageCubit extends Cubit<MainImageState> {
   }
 
   void reset() {
+    image = null;
+    imageUrl = null;
     emit(MainImageInitial());
   }
 
@@ -24,14 +25,18 @@ class MainImageCubit extends Cubit<MainImageState> {
   }
 
   Future<void> pickImage(Function(File) onImagePicked) async {
-    final pickedFile =
-        await ImagePicker().pickImage(source: ImageSource.gallery);
-    if (pickedFile != null) {
-      image = File(pickedFile.path);
-      onImagePicked(image!);
-      emit(MainImageLoaded(imageFile: image!));
-    } else {
-      emit(const MainImageFaliure('Failed to pick imaggggggggge'));
+    try {
+      final pickedFile =
+          await ImagePicker().pickImage(source: ImageSource.gallery);
+      if (pickedFile != null) {
+        image = File(pickedFile.path);
+        onImagePicked(image!);
+        emit(MainImageLoaded(imageFile: image!));
+      } else {
+        emit(const MainImageFaliure('Failed to pick image'));
+      }
+    } catch (e) {
+      emit(MainImageFaliure('Failed to pick image: $e'));
     }
   }
 }

--- a/lib/features/new_vehicle/data/cubits/map_location/map_location_cubit.dart
+++ b/lib/features/new_vehicle/data/cubits/map_location/map_location_cubit.dart
@@ -239,4 +239,9 @@ class MapLocationCubit extends Cubit<MapLocationState> {
           : selectedAddress,
     };
   }
+
+  void reset() {
+    selectedLocation = null;
+    emit(MapLocationInitial());
+  }
 }

--- a/lib/features/new_vehicle/presentation/views/add_vehicle_screen.dart
+++ b/lib/features/new_vehicle/presentation/views/add_vehicle_screen.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: use_build_context_synchronously
+
 import 'package:aggar/core/cubit/refresh%20token/token_refresh_cubit.dart';
 import 'package:aggar/core/extensions/context_colors_extension.dart';
 import 'package:aggar/core/helper/custom_snack_bar.dart';
@@ -31,11 +33,52 @@ class AddVehicleScreen extends StatefulWidget {
 class _AddVehicleScreenState extends State<AddVehicleScreen> {
   String? _accessToken;
   bool isLoading = true;
+  bool _isFirstBuild = true;
 
   @override
   void initState() {
     super.initState();
+    if (_isFirstBuild) {
+      _resetAllState();
+      _isFirstBuild = false;
+    }
     _loadToken();
+  }
+
+  void _resetAllState() {
+    // Reset AddVehicleCubit state
+    final addVehicleCubit = context.read<AddVehicleCubit>();
+    addVehicleCubit.reset();
+
+    // Reset form controllers
+    addVehicleCubit.vehicleModelController.clear();
+    addVehicleCubit.vehicleRentalPrice.clear();
+    addVehicleCubit.vehicleYearOfManufactureController.clear();
+    addVehicleCubit.vehicleColorController.clear();
+    addVehicleCubit.vehicleSeatsNoController.clear();
+    addVehicleCubit.vehicleProperitesOverviewController.clear();
+    addVehicleCubit.vehicleBrandController.clear();
+    addVehicleCubit.vehicleTypeController.clear();
+    addVehicleCubit.vehicleStatusController.clear();
+    addVehicleCubit.vehicleAddressController.clear();
+
+    // Reset other state values
+    addVehicleCubit.selectedTransmissionModeValue = 0;
+    addVehicleCubit.selectedVehicleBrandValue = null;
+    addVehicleCubit.selectedVehicleTypeValue = null;
+    addVehicleCubit.selectedVehicleStatusValue = null;
+    addVehicleCubit.selectedVehicleBrandId = null;
+    addVehicleCubit.selectedVehicleTypeId = null;
+    addVehicleCubit.selectedVehicleHealthValue = null;
+
+    // Reset MapLocationCubit
+    context.read<MapLocationCubit>().reset();
+
+    // Reset MainImageCubit
+    context.read<MainImageCubit>().reset();
+
+    // Reset AdditionalImageCubit
+    context.read<AdditionalImageCubit>().reset();
   }
 
   Future<void> _loadToken() async {
@@ -47,7 +90,6 @@ class _AddVehicleScreenState extends State<AddVehicleScreen> {
         _accessToken = token;
         isLoading = false;
       });
-
       await _fetchInitialData(token);
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -87,7 +129,7 @@ class _AddVehicleScreenState extends State<AddVehicleScreen> {
             customSnackBar(
               context,
               "Error",
-              "Failed to add vehicle!",
+              state.message,
               SnackBarType.error,
             ),
           );
@@ -96,6 +138,7 @@ class _AddVehicleScreenState extends State<AddVehicleScreen> {
       builder: (context, state) {
         return Scaffold(
           bottomNavigationBar: BottomNavigationBarContent(
+            color: context.theme.blue100_1,
             title: "Add Vehicle",
             onPressed: () async {
               if (_accessToken == null) {
@@ -173,6 +216,7 @@ class _AddVehicleScreenState extends State<AddVehicleScreen> {
                     key: context.read<AddVehicleCubit>().addVehicleFormKey,
                     child: Column(
                       children: [
+                        const Gap(25),
                         AboutVehicleSection(
                           modelController: context
                               .read<AddVehicleCubit>()
@@ -228,13 +272,12 @@ class _AddVehicleScreenState extends State<AddVehicleScreen> {
                               .read<AddVehicleCubit>()
                               .vehicleStatusController,
                         ),
-                        const Gap(25),
+                        const Gap(35),
                       ],
                     ),
                   ),
                 ),
               ),
-              // Loading indicator
               if (state is AddVehicleLoading)
                 Container(
                   color: Colors.black.withOpacity(0.3),

--- a/lib/features/new_vehicle/presentation/widgets/about_vehicle_section.dart
+++ b/lib/features/new_vehicle/presentation/widgets/about_vehicle_section.dart
@@ -113,6 +113,11 @@ class AboutVehicleSection extends StatelessWidget {
                 if (value!.isEmpty) {
                   return "required";
                 }
+                final year = int.tryParse(value);
+                final currentYear = DateTime.now().year;
+                if (year == null || year < 1900 || year > currentYear) {
+                  return "from 1900 to $currentYear";
+                }
                 return null;
               },
               controller: yearOfManufactureController,

--- a/lib/features/new_vehicle/presentation/widgets/add_image_button.dart
+++ b/lib/features/new_vehicle/presentation/widgets/add_image_button.dart
@@ -27,7 +27,7 @@ class AddImageButton extends StatelessWidget {
         child: MaterialButton(
           padding: EdgeInsets.zero,
           elevation: 0,
-          color: context.theme.blue100_2,
+          color: context.theme.blue100_1,
           splashColor: context.theme.white50_1,
           highlightColor: context.theme.white50_1,
           shape: const CircleBorder(),

--- a/lib/features/new_vehicle/presentation/widgets/additional_image_card.dart
+++ b/lib/features/new_vehicle/presentation/widgets/additional_image_card.dart
@@ -17,52 +17,53 @@ class AdditionalImageCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-        onTap: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => FullScreenPhotoView(
-                image: image,
-                onRemove: onRemove,
-              ),
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => FullScreenPhotoView(
+              image: image,
+              onRemove: onRemove,
             ),
-          );
-        },
-        onLongPress: onRemove != null
-            ? () => showDialog(
-                  context: context,
-                  builder: (context) => CustomDialog(
-                    title: "Remove Image",
-                    actionTitle: "Remove",
-                    subtitle: 'Are you sure you want to remove this image?',
-                    onPressed: () {
-                      Navigator.pop(context);
-                      onRemove?.call();
-                    },
-                  ),
-                )
-            : null,
-        child: Container(
-          margin: const EdgeInsets.only(right: 10),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(5),
-            boxShadow: [
-              BoxShadow(
-                color: context.theme.black25,
-                offset: const Offset(0, 0),
-                blurRadius: 2,
+          ),
+        );
+      },
+      onLongPress: onRemove != null
+          ? () => showDialog(
+                context: context,
+                builder: (context) => CustomDialog(
+                  title: "Remove Image",
+                  actionTitle: "Remove",
+                  subtitle: 'Are you sure you want to remove this image?',
+                  onPressed: () {
+                    Navigator.pop(context);
+                    onRemove?.call();
+                  },
+                ),
               )
-            ],
+          : null,
+      child: Container(
+        margin: const EdgeInsets.only(right: 10),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(5),
+          boxShadow: [
+            BoxShadow(
+              color: context.theme.black25,
+              offset: const Offset(0, 0),
+              blurRadius: 2,
+            )
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(5),
+          child: Image.file(
+            image,
+            fit: BoxFit.cover,
+            height: MediaQuery.sizeOf(context).height * 0.03 + 50,
+            width: MediaQuery.sizeOf(context).height * 0.03 + 50,
           ),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(5),
-            child: Image.file(
-              image,
-              fit: BoxFit.cover,
-              height: MediaQuery.sizeOf(context).height * 0.03 + 50,
-              width: MediaQuery.sizeOf(context).height * 0.03 + 50,
-            ),
-          ),
-        ));
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/new_vehicle/presentation/widgets/confirm_location_with_pick_current_location.dart
+++ b/lib/features/new_vehicle/presentation/widgets/confirm_location_with_pick_current_location.dart
@@ -6,12 +6,25 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ConfirmLocationWithPickCurrentLocation extends StatelessWidget {
-  const ConfirmLocationWithPickCurrentLocation({super.key});
+  final String? uniqueId;
+
+  // Static counters to ensure unique hero tags
+  static int _pickLocationCounter = 0;
+  static int _confirmLocationCounter = 0;
+
+  const ConfirmLocationWithPickCurrentLocation({
+    super.key,
+    this.uniqueId,
+  });
 
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<MapLocationCubit, MapLocationState>(
       builder: (context, state) {
+        final pickLocationTag = 'pick_location_${_pickLocationCounter++}';
+        final confirmLocationTag =
+            'confirm_location_${_confirmLocationCounter++}';
+
         return Positioned(
           right: 25,
           bottom: MediaQuery.sizeOf(context).height * 0.21,
@@ -24,7 +37,7 @@ class ConfirmLocationWithPickCurrentLocation extends StatelessWidget {
                     50,
                   ),
                 ),
-                heroTag: 'pickCurrentLocation',
+                heroTag: pickLocationTag,
                 backgroundColor: context.theme.blue100_1,
                 onPressed: () =>
                     context.read<MapLocationCubit>().getCurrentLocation(),
@@ -40,7 +53,7 @@ class ConfirmLocationWithPickCurrentLocation extends StatelessWidget {
                     50,
                   ),
                 ),
-                heroTag: 'confirmLocation',
+                heroTag: confirmLocationTag,
                 backgroundColor: context.theme.blue100_1,
                 onPressed: () {
                   final locationData = context

--- a/lib/features/new_vehicle/presentation/widgets/main_image_card.dart
+++ b/lib/features/new_vehicle/presentation/widgets/main_image_card.dart
@@ -1,34 +1,53 @@
 import 'dart:io';
 import 'package:aggar/core/extensions/context_colors_extension.dart';
+import 'package:aggar/core/widgets/full_screen_photo_view.dart';
 import 'package:flutter/material.dart';
 
 class MainImageCard extends StatelessWidget {
+  final File? image;
+  final VoidCallback? onRemove;
+
   const MainImageCard({
     super.key,
     required this.image,
+    this.onRemove,
   });
-
-  final File? image;
 
   @override
   Widget build(BuildContext context) {
-    //TODO:make it clickable
-    return Container(
-      decoration:
-          BoxDecoration(borderRadius: BorderRadius.circular(5), boxShadow: [
-        BoxShadow(
-          color: context.theme.black25,
-          offset: const Offset(0, 0),
-          blurRadius: 2,
-        )
-      ]),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(5),
-        child: Image.file(
-          image!,
-          fit: BoxFit.cover,
-          height: MediaQuery.of(context).size.height * 0.25,
-          width: double.infinity,
+    return GestureDetector(
+      onTap: () {
+        if (image != null) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => FullScreenPhotoView(
+                image: image!,
+                onRemove: onRemove,
+              ),
+            ),
+          );
+        }
+      },
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(5),
+          boxShadow: [
+            BoxShadow(
+              color: context.theme.black25,
+              offset: const Offset(0, 0),
+              blurRadius: 2,
+            )
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(5),
+          child: Image.file(
+            image!,
+            fit: BoxFit.cover,
+            height: MediaQuery.of(context).size.height * 0.25,
+            width: double.infinity,
+          ),
         ),
       ),
     );

--- a/lib/features/new_vehicle/presentation/widgets/map_screen.dart
+++ b/lib/features/new_vehicle/presentation/widgets/map_screen.dart
@@ -2,31 +2,43 @@ import 'package:aggar/core/helper/custom_snack_bar.dart';
 import 'package:aggar/features/new_vehicle/presentation/widgets/address_search_bar.dart';
 import 'package:aggar/features/new_vehicle/presentation/widgets/pick_image_map.dart';
 import 'package:aggar/features/new_vehicle/presentation/widgets/selected_location_section.dart';
-import 'package:aggar/features/new_vehicle/presentation/widgets/confirm_location_with_pick_current_location.dart'; // Added import
+import 'package:aggar/features/new_vehicle/presentation/widgets/confirm_location_with_pick_current_location.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:aggar/features/new_vehicle/data/cubits/map_location/map_location_cubit.dart';
 import 'package:aggar/features/new_vehicle/data/cubits/map_location/map_location_state.dart';
+import 'package:uuid/uuid.dart';
 
 import '../../../../core/services/location_state_type.dart';
 
 class MapScreen extends StatelessWidget {
   final LatLng? initialLocation;
+  final String? screenId;
 
-  const MapScreen({super.key, this.initialLocation});
+  const MapScreen({
+    super.key,
+    this.initialLocation,
+    this.screenId,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final uniqueId = screenId ?? const Uuid().v4();
+
     return BlocProvider(
       create: (context) => MapLocationCubit(initialLocation: initialLocation),
-      child: const _MapScreenContent(),
+      child: _MapScreenContent(uniqueId: uniqueId),
     );
   }
 }
 
 class _MapScreenContent extends StatelessWidget {
-  const _MapScreenContent();
+  final String uniqueId;
+
+  const _MapScreenContent({
+    required this.uniqueId,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -60,7 +72,8 @@ class _MapScreenContent extends StatelessWidget {
                 right: 16,
                 child: AddressSearchBar(),
               ),
-              const ConfirmLocationWithPickCurrentLocation(),
+              ConfirmLocationWithPickCurrentLocation(
+                  uniqueId: 'map_screen_$uniqueId'),
               if (currentAddress.isNotEmpty)
                 SelectedLocationSection(
                   isLoading: isLoading,

--- a/lib/features/new_vehicle/presentation/widgets/pick_location_on_map_button.dart
+++ b/lib/features/new_vehicle/presentation/widgets/pick_location_on_map_button.dart
@@ -3,6 +3,7 @@ import 'package:aggar/core/utils/app_styles.dart';
 import 'package:aggar/features/new_vehicle/presentation/widgets/map_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:uuid/uuid.dart';
 
 class PickLocationOnMapButton extends StatelessWidget {
   const PickLocationOnMapButton({
@@ -13,6 +14,8 @@ class PickLocationOnMapButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final String uniqueId = const Uuid().v4();
+
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(5),
@@ -31,7 +34,7 @@ class PickLocationOnMapButton extends StatelessWidget {
           final result = await Navigator.push(
             context,
             MaterialPageRoute(
-              builder: (context) => const MapScreen(),
+              builder: (context) => MapScreen(screenId: uniqueId),
             ),
           );
 

--- a/lib/features/new_vehicle/presentation/widgets/pick_main_image_button_content.dart
+++ b/lib/features/new_vehicle/presentation/widgets/pick_main_image_button_content.dart
@@ -109,13 +109,18 @@ class _PickMainImageButtonContentState
       return GestureDetector(
         onTap: () => _pickImage(field, context),
         child: state.imageFile != null
-            ? MainImageCard(image: state.imageFile!)
+            ? MainImageCard(
+                image: state.imageFile!,
+                onRemove: () {
+                  context.read<MainImageCubit>().reset();
+                  field.didChange(null);
+                },
+              )
             : state.imageUrl != null && state.imageUrl!.isNotEmpty
                 ? ClipRRect(
                     borderRadius: BorderRadius.circular(5),
                     child: Image.network(
                       state.imageUrl!.startsWith('http')
-                          //TODO : endpoint for image url
                           ? state.imageUrl!
                           : "https://aggarapi.runasp.net${state.imageUrl!}",
                       fit: BoxFit.cover,
@@ -144,7 +149,28 @@ class _PickMainImageButtonContentState
                   ),
       );
     } else if (state is MainImageFaliure) {
-      return Center(child: Text(state.message));
+      return PickMainImageButtonStyle(
+        onPressed: () {
+          context.read<MainImageCubit>().reset();
+          _pickImage(field, context);
+        },
+        widget: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Image(
+              image: const AssetImage(AppAssets.assetsIconsPickimage),
+              height: MediaQuery.of(context).size.width * 0.1,
+            ),
+            Text(
+              "click here to pick \nmain image ",
+              textAlign: TextAlign.center,
+              style: AppStyles.regular16(context).copyWith(
+                color: context.theme.blue100_1,
+              ),
+            )
+          ],
+        ),
+      );
     }
     return Container();
   }

--- a/lib/features/new_vehicle/presentation/widgets/selected_location_map_contnet.dart
+++ b/lib/features/new_vehicle/presentation/widgets/selected_location_map_contnet.dart
@@ -2,22 +2,31 @@ import 'package:aggar/core/extensions/context_colors_extension.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
+
 import 'map_screen.dart';
 
 class SelectedLocationMapContent extends StatelessWidget {
   final LatLng location;
   final String address;
   final Function(LatLng, String) onEditLocation;
+  final String uniqueId;
+
+  // Static counter to ensure unique hero tags
+  static int _editLocationCounter = 0;
 
   const SelectedLocationMapContent({
     super.key,
     required this.location,
     required this.address,
     required this.onEditLocation,
+    required this.uniqueId,
   });
 
   @override
   Widget build(BuildContext context) {
+    // Generate a unique tag using the counter
+    final String buttonTag = 'edit_location_${_editLocationCounter++}';
+
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(5),
@@ -71,12 +80,15 @@ class SelectedLocationMapContent extends StatelessWidget {
               bottom: 8,
               right: 8,
               child: FloatingActionButton.small(
+                heroTag: buttonTag,
                 onPressed: () async {
                   final result = await Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) =>
-                          MapScreen(initialLocation: location),
+                      builder: (context) => MapScreen(
+                        initialLocation: location,
+                        screenId: buttonTag,
+                      ),
                     ),
                   );
 

--- a/lib/features/new_vehicle/presentation/widgets/vehicle_health_button.dart
+++ b/lib/features/new_vehicle/presentation/widgets/vehicle_health_button.dart
@@ -49,7 +49,7 @@ class VehicleHealthButton extends StatelessWidget {
             context.theme.white50_1,
           ),
           backgroundColor: WidgetStatePropertyAll(
-            isSelected ? context.theme.white100_1 : context.theme.blue100_2,
+            isSelected ? context.theme.white100_1 : context.theme.blue100_1,
           ),
         ),
         onPressed: () => onPressed(text),

--- a/lib/features/new_vehicle/presentation/widgets/vehicle_health_options.dart
+++ b/lib/features/new_vehicle/presentation/widgets/vehicle_health_options.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 
-class VehicleHealthOptions extends StatelessWidget {
+class VehicleHealthOptions extends StatefulWidget {
   final bool isEditing;
   final String? initialVehicleHealth;
 
@@ -18,32 +18,23 @@ class VehicleHealthOptions extends StatelessWidget {
     this.isEditing = false,
     this.initialVehicleHealth,
   });
+
   @override
-  Widget build(BuildContext context) {
-    if (isEditing &&
-        initialVehicleHealth != null &&
+  State<VehicleHealthOptions> createState() => _VehicleHealthOptionsState();
+}
+
+class _VehicleHealthOptionsState extends State<VehicleHealthOptions> {
+  @override
+  void initState() {
+    super.initState();
+    if (widget.isEditing &&
+        widget.initialVehicleHealth != null &&
         context.read<EditVehicleCubit>().selectedVehicleHealthValue == null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        final healthValue = _mapHealthValueToUI(initialVehicleHealth!);
+        final healthValue = _mapHealthValueToUI(widget.initialVehicleHealth!);
         context.read<EditVehicleCubit>().setVehicleHealth(healthValue);
       });
     }
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          "Vehicle Health",
-          style: AppStyles.medium18(context).copyWith(
-            color: context.theme.blue100_1,
-          ),
-        ),
-        const Gap(10),
-        if (isEditing)
-          _buildEditingMode(context)
-        else
-          _buildAddingMode(context),
-      ],
-    );
   }
 
   String _mapHealthValueToUI(String apiValue) {
@@ -59,6 +50,26 @@ class VehicleHealthOptions extends StatelessWidget {
       default:
         return "";
     }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          "Vehicle Health",
+          style: AppStyles.medium18(context).copyWith(
+            color: context.theme.blue100_1,
+          ),
+        ),
+        const Gap(10),
+        if (widget.isEditing)
+          _buildEditingMode(context)
+        else
+          _buildAddingMode(context),
+      ],
+    );
   }
 
   Widget _buildEditingMode(BuildContext context) {
@@ -85,13 +96,14 @@ class VehicleHealthOptions extends StatelessWidget {
                           text: 'Excellent',
                           isSelected: selectedValue == 'Excellent',
                           onPressed: (value) {
-                            if (isEditing == true) {
+                            if (widget.isEditing) {
                               cubit.setVehicleHealth(value);
                             } else {
                               context
                                   .read<AddVehicleCubit>()
                                   .setVehicleHealth(value);
                             }
+                            setState(() {});
                           },
                         ),
                         const SizedBox(height: 25),
@@ -99,13 +111,14 @@ class VehicleHealthOptions extends StatelessWidget {
                           text: 'Minor dents',
                           isSelected: selectedValue == 'Minor dents',
                           onPressed: (value) {
-                            if (isEditing == true) {
+                            if (widget.isEditing) {
                               cubit.setVehicleHealth(value);
                             } else {
                               context
                                   .read<AddVehicleCubit>()
                                   .setVehicleHealth(value);
                             }
+                            setState(() {});
                           },
                         ),
                       ],
@@ -119,13 +132,14 @@ class VehicleHealthOptions extends StatelessWidget {
                           text: 'Good',
                           isSelected: selectedValue == 'Good',
                           onPressed: (value) {
-                            if (isEditing == true) {
+                            if (widget.isEditing) {
                               cubit.setVehicleHealth(value);
                             } else {
                               context
                                   .read<AddVehicleCubit>()
                                   .setVehicleHealth(value);
                             }
+                            setState(() {});
                           },
                         ),
                         const SizedBox(height: 25),
@@ -133,13 +147,14 @@ class VehicleHealthOptions extends StatelessWidget {
                           text: 'Not bad',
                           isSelected: selectedValue == 'Not bad',
                           onPressed: (value) {
-                            if (isEditing == true) {
+                            if (widget.isEditing) {
                               cubit.setVehicleHealth(value);
                             } else {
                               context
                                   .read<AddVehicleCubit>()
                                   .setVehicleHealth(value);
                             }
+                            setState(() {});
                           },
                         ),
                       ],
@@ -188,13 +203,21 @@ class VehicleHealthOptions extends StatelessWidget {
                         VehicleHealthButton(
                           text: 'Excellent',
                           isSelected: selectedValue == 'Excellent',
-                          onPressed: (value) => cubit.setVehicleHealth(value),
+                          onPressed: (value) {
+                            cubit.setVehicleHealth(value);
+                            field.didChange(value);
+                            setState(() {});
+                          },
                         ),
                         const SizedBox(height: 25),
                         VehicleHealthButton(
                           text: 'Minor dents',
                           isSelected: selectedValue == 'Minor dents',
-                          onPressed: (value) => cubit.setVehicleHealth(value),
+                          onPressed: (value) {
+                            cubit.setVehicleHealth(value);
+                            field.didChange(value);
+                            setState(() {});
+                          },
                         ),
                       ],
                     ),
@@ -206,13 +229,21 @@ class VehicleHealthOptions extends StatelessWidget {
                         VehicleHealthButton(
                           text: 'Good',
                           isSelected: selectedValue == 'Good',
-                          onPressed: (value) => cubit.setVehicleHealth(value),
+                          onPressed: (value) {
+                            cubit.setVehicleHealth(value);
+                            field.didChange(value);
+                            setState(() {});
+                          },
                         ),
                         const SizedBox(height: 25),
                         VehicleHealthButton(
                           text: 'Not bad',
                           isSelected: selectedValue == 'Not bad',
-                          onPressed: (value) => cubit.setVehicleHealth(value),
+                          onPressed: (value) {
+                            cubit.setVehicleHealth(value);
+                            field.didChange(value);
+                            setState(() {});
+                          },
                         ),
                       ],
                     ),

--- a/lib/features/new_vehicle/presentation/widgets/vehicle_pick_location_on_map_section.dart
+++ b/lib/features/new_vehicle/presentation/widgets/vehicle_pick_location_on_map_section.dart
@@ -5,6 +5,7 @@ import 'package:aggar/features/new_vehicle/presentation/widgets/selected_locatio
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:uuid/uuid.dart';
 
 class VehiclePickLocationOnMapSection extends StatefulWidget {
   final LatLng? initialLocation;
@@ -24,6 +25,8 @@ class _VehiclePickLocationOnMapSectionState
   LatLng? selectedLocation;
   final GlobalKey<FormFieldState> _formFieldKey = GlobalKey<FormFieldState>();
   String address = '';
+  final String uniqueId = const Uuid().v4();
+
   @override
   void initState() {
     super.initState();
@@ -79,15 +82,15 @@ class _VehiclePickLocationOnMapSectionState
                     _formFieldKey.currentState?.validate();
                     widget.onLocationSelected?.call(location, locationAddress);
                   },
+                  uniqueId: uniqueId,
                 ),
               if (field.hasError)
                 Padding(
-                  padding: const EdgeInsets.only(top: 8.0),
+                  padding: const EdgeInsets.only(top: 8.0, left: 4.0),
                   child: Text(
                     field.errorText!,
-                    style: const TextStyle(
-                      color: Colors.red,
-                      fontSize: 12,
+                    style: AppStyles.regular14(context).copyWith(
+                      color: context.theme.red100_1,
                     ),
                   ),
                 ),

--- a/lib/features/new_vehicle/presentation/widgets/vehicle_properites_section.dart
+++ b/lib/features/new_vehicle/presentation/widgets/vehicle_properites_section.dart
@@ -5,6 +5,7 @@ import 'package:aggar/features/new_vehicle/presentation/widgets/properites_over_
 import 'package:aggar/features/new_vehicle/presentation/widgets/transmission_mode_options.dart';
 import 'package:aggar/features/new_vehicle/presentation/widgets/vehicle_health_options.dart';
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 
 class VehicleProperitesSection extends StatelessWidget {
   final TextEditingController vehicleColorController;
@@ -33,8 +34,10 @@ class VehicleProperitesSection extends StatelessWidget {
             color: context.theme.blue100_2,
           ),
         ),
+        const Gap(10),
         Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: 10,
           children: [
             PickColorAndSeatsNumFields(
               vehicleColorController: vehicleColorController,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,10 +50,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   bloc:
     dependency: "direct main"
     description:
@@ -66,10 +66,10 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   build:
     dependency: transitive
     description:
@@ -106,26 +106,26 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   connectivity_plus:
     dependency: "direct main"
     description:
@@ -290,10 +290,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -862,18 +862,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -974,10 +974,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -998,10 +998,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1118,10 +1118,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_parsing:
     dependency: transitive
     description:
@@ -1467,10 +1467,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   sprintf:
     dependency: transitive
     description:
@@ -1539,18 +1539,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -1563,10 +1563,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   synchronized:
     dependency: transitive
     description:
@@ -1587,18 +1587,18 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   timezone:
     dependency: "direct main"
     description:
@@ -1640,7 +1640,7 @@ packages:
     source: hosted
     version: "0.3.1"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
@@ -1683,10 +1683,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.3.1"
   watcher:
     dependency: transitive
     description:
@@ -1800,5 +1800,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -88,6 +88,7 @@ dependencies:
   dartz: ^0.10.1  # For functional programming
   table_calendar: ^3.1.3
   webview_flutter: ^4.13.0
+  uuid: ^4.3.3  # For generating unique identifiers
 dev_dependencies:
   flutter_lints: ^4.0.0
   flutter_test:


### PR DESCRIPTION

- Implemented reset methods in AdditionalImageCubit, MainImageCubit, and MapLocationCubit to clear their states.
- Enhanced AddVehicleScreen to reset all relevant cubits and form controllers on first build.
- Added validation for year of manufacture in AboutVehicleSection.
- Updated UI components to ensure consistent styling and behavior, including image cards and buttons.
- Introduced unique hero tags for navigation in ConfirmLocationWithPickCurrentLocation and SelectedLocationMapContent.
- Refactored VehicleHealthOptions to use StatefulWidget for better state management during editing.